### PR TITLE
Fix for regular expressions in value checks

### DIFF
--- a/stage2/03-create-asgs-csv-schema.sql
+++ b/stage2/03-create-asgs-csv-schema.sql
@@ -17,67 +17,67 @@ CREATE SCHEMA asgs_2011;
 
 CREATE DOMAIN asgs_2011.state_code AS char(1)
 CHECK (
-  VALUE ~ '^\d$'
+  VALUE ~ E'^\\d$'
 );
 
 CREATE DOMAIN asgs_2011.gccsa_code AS char(5)
 CHECK (
-  VALUE ~ '^\d\w{4}$'
+  VALUE ~ E'^\\d\\w{4}$'
 );
 
 CREATE DOMAIN asgs_2011.sa4_code AS char(3)
 CHECK (
-  VALUE ~ '^\d{3}$'
+  VALUE ~ E'^\\d{3}$'
 );
 
 CREATE DOMAIN asgs_2011.sa3_code AS char(5)
 CHECK (
-  VALUE ~ '^\d{5}$'
+  VALUE ~ E'^\\d{5}$'
 );
 
 CREATE DOMAIN asgs_2011.sa2_code AS char(9)
 CHECK (
-  VALUE ~ '^\d{9}$'
+  VALUE ~ E'^\\d{9}$'
 );
 
 CREATE DOMAIN asgs_2011.sa1_code AS char(11)
 CHECK (
-  VALUE ~ '^\d{11}$'
+  VALUE ~ E'^\\d{11}$'
 );
 
 CREATE DOMAIN asgs_2011.mb_code AS char(11)
 CHECK (
-  VALUE ~ '^\d{11}$'
+  VALUE ~ E'^\\d{11}$'
 );
 
 CREATE DOMAIN asgs_2011.add_code AS char(3)
 CHECK (
-  VALUE ~ '^D\d{2}$'
+  VALUE ~ E'^[D\\d]\\d{2}$'
 );
 
 CREATE DOMAIN asgs_2011.poa_code AS char(4)
 CHECK (
-  VALUE ~ '^\d{4}$'
+  VALUE ~ E'^\\d{4}$'
 );
 
 CREATE DOMAIN asgs_2011.ssc_code AS char(5)
 CHECK (
-  VALUE ~ '^\d{5}$'
+  VALUE ~ E'^\\d{5}$'
 );
 
 CREATE DOMAIN asgs_2011.ced_code AS char(3)
 CHECK (
-  VALUE ~ '^\d{3}$'
+  VALUE ~ E'^\\d{3}$'
 );
 
 CREATE DOMAIN asgs_2011.sed_code AS char(5)
 CHECK (
-  VALUE ~ '^\d{5}$'
+  VALUE ~ E'^\\d{5}$'
 );
 
 CREATE DOMAIN asgs_2011.nrmr_code AS char(3)
 CHECK (
-  VALUE ~ '^\d{3}$'
+  VALUE ~ E'^\\d{3}$'
 );
 
 CREATE DOMAIN asgs_2011.lga_code AS char(5)
@@ -102,7 +102,7 @@ CHECK (
 
 CREATE DOMAIN asgs_2011.ireg_code AS char(3)
 CHECK (
-  VALUE ~ '^\d{3}$'
+  VALUE ~ E'^\\d{3}$'
 );
 
 


### PR DESCRIPTION
I've tried to use these scripts on both PostGis 1.5.4 (windows based) and Postgis 2.0.0 (linux based) (both using the default configuration option standard_conforming_strings=on) and on both setups the make script fails in 03-create-asgs-csv-schema.sql when the checks are created. For my setups, I had to escape the slashes within the regular expressions to get this file to run correctly.
